### PR TITLE
Various helpful additions and changes

### DIFF
--- a/src/JviguyGames1994/Concurrency/Concurrency.php
+++ b/src/JviguyGames1994/Concurrency/Concurrency.php
@@ -10,12 +10,15 @@ use JviguyGames1994\Concurrency\Economy\EconomyHandlers;
 use pocketmine\plugin\PluginBase;
 
 class Concurrency extends PluginBase{
-	private static $instance;
+	
+	private static $handlers;
+	
 	public function onEnable()
 	{
-		self::$instance = new EconomyHandlers($this);
+		self::$handlers = new EconomyHandlers($this);
 	}
-	public static function getInstance(){
+	
+	public static function getHandlers() : EconomyHandlers{
 		return self::$instance;
 	}
 }

--- a/src/JviguyGames1994/Concurrency/Economy/BaseEconomies/BaseEconomy.php
+++ b/src/JviguyGames1994/Concurrency/Economy/BaseEconomies/BaseEconomy.php
@@ -21,6 +21,7 @@ abstract class BaseEconomy
 	abstract public function add(string $uuid, int $amount);
 	abstract public function subtract(string $uuid, int $amount);
 	abstract public function get(string $uuid);
+	abstract public function reset(string $uuid);
 	abstract public function set(string $uuid, int $amount);
 	abstract public function sum(string $uuid, int $amount);
 	abstract protected function removeBalance(string $uuid);

--- a/src/JviguyGames1994/Concurrency/Economy/BaseEconomies/RoundedEconomy.php
+++ b/src/JviguyGames1994/Concurrency/Economy/BaseEconomies/RoundedEconomy.php
@@ -85,6 +85,16 @@ class RoundedEconomy extends BaseEconomy
 			//TODO: error tracing
 		}
 	}
+	
+	public function reset(string $uuid)
+	{
+		try{
+			$b = $this->getBalance($uuid);
+			$b->setAmount(0);
+		} catch (\InvalidArgumentException $exception){
+			//TODO: error tracing
+		}
+	}
 
 	public function sum(string $uuid, int $amount)
 	{

--- a/src/JviguyGames1994/Concurrency/Economy/EconomyHandlers.php
+++ b/src/JviguyGames1994/Concurrency/Economy/EconomyHandlers.php
@@ -7,7 +7,7 @@ use JviguyGames1994\Concurrency\Economy\BaseEconomies\BaseEconomy;
 use JviguyGames1994\Concurrency\Economy\Listeners\RegisterHandler;
 use pocketmine\Server;
 
-class EconomyHandlers
+final class EconomyHandlers
 {
 	/** @var BaseEconomy[] $economys */
 	private $economys;

--- a/src/JviguyGames1994/Concurrency/Economy/EconomyHandlers.php
+++ b/src/JviguyGames1994/Concurrency/Economy/EconomyHandlers.php
@@ -10,30 +10,29 @@ use pocketmine\Server;
 
 class EconomyHandlers
 {
-	/** @var array $economys */
+	/** @var BaseEconomy[] $economys */
 	private $economys;
 	/** @var string $provider */
 	private $provider;
-	/** @var EconomyHandlers $instance */
-	private static $instance;
+
 	public function __construct(Concurrency $main)
 	{
 		Server::getInstance()->getPluginManager()->registerEvents(new RegisterHandler($this), $main);
 	}
-	public static function getInstance(): ?EconomyHandlers {
-		return self::$instance;
-	}
+	
 	public function registerNewEconomy(BaseEconomy $economy, string $name){
 		$this->economys[$name] = $economy;
 	}
+	
 	public function getEconomy(string $name): BaseEconomy{
 		try{
 			return $this->economys[$name];
 		} catch (\ErrorException $exception){
 			throw new InvalidArgumentException("economy $name doesnt Exist!");
-		}
+		} //in php8 you will be able to throw exceptions with the null coalescing operator
 	}
-	public function getEconomies(): array{
-		return$this->economys;
+	
+	public function getEconomies(){
+		return $this->economys;
 	}
 }

--- a/src/JviguyGames1994/Concurrency/Economy/EconomyHandlers.php
+++ b/src/JviguyGames1994/Concurrency/Economy/EconomyHandlers.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 namespace JviguyGames1994\Concurrency\Economy;
 
-use http\Exception\InvalidArgumentException;
 use JviguyGames1994\Concurrency\Concurrency;
 use JviguyGames1994\Concurrency\Economy\BaseEconomies\BaseEconomy;
 use JviguyGames1994\Concurrency\Economy\Listeners\RegisterHandler;
@@ -28,7 +27,7 @@ class EconomyHandlers
 		try{
 			return $this->economys[$name];
 		} catch (\ErrorException $exception){
-			throw new InvalidArgumentException("economy $name doesnt Exist!");
+			throw new \InvalidArgumentException("economy $name doesnt Exist!");
 		} //in php8 you will be able to throw exceptions with the null coalescing operator
 	}
 	

--- a/src/JviguyGames1994/Concurrency/Economy/Events/AddMoneyEvent.php
+++ b/src/JviguyGames1994/Concurrency/Economy/Events/AddMoneyEvent.php
@@ -9,5 +9,8 @@ class AddMoneyEvent extends MoneyChangeEvent
 	public function __construct(string $uuid, int $change)
 	{
 		parent::__construct($uuid, $change);
+		if($change < 0){
+			$this->setCancelled();
+		}
 	}
 }

--- a/src/JviguyGames1994/Concurrency/Economy/Events/MoneyChangeEvent.php
+++ b/src/JviguyGames1994/Concurrency/Economy/Events/MoneyChangeEvent.php
@@ -15,6 +15,9 @@ class MoneyChangeEvent extends Event implements Cancellable
 	private $change;
 	public function __construct(string $uuid, int $change)
 	{
+		if($change == 0){
+			$this->setCancelled();
+		}
 		$this->uuid = $uuid;
 		$this->change = $change;
 	}

--- a/src/JviguyGames1994/Concurrency/Economy/Events/SubtractMoneyEvent.php
+++ b/src/JviguyGames1994/Concurrency/Economy/Events/SubtractMoneyEvent.php
@@ -8,5 +8,8 @@ class SubtractMoneyEvent extends MoneyChangeEvent
 	public function __construct(string $uuid, int $change)
 	{
 		parent::__construct($uuid, $change);
+		if($change > 0){
+			$this->setCancelled();
+		}	
 	}
 }


### PR DESCRIPTION
1. Removed silly `getInstance()`s of both Concurrency.php and EconomyHandlers.php - it is now `Concurrency::getHandlers()`
2. Cancel MoneyAddEvent and MoneySubtractEvent if the amounts are respectively less than or greater than 0, cancel MoneyChangeEvent is the amount is 0
3. Used correct/likely intended InvalidArgumentException
4. Added reset() method to BaseEconomy.php, allows for resetting a player's balance back to 0 without unsetting their balance entirely